### PR TITLE
feat: Configuration Docker pour Railway

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Copier les fichiers de dépendances
+COPY package*.json ./
+COPY server/package*.json ./server/
+
+# Installer les dépendances
+RUN npm ci --production=false
+RUN cd server && npm ci --production=false
+
+# Copier le reste des fichiers
+COPY . .
+
+# Vérifier les modèles
+RUN echo "=== Vérification des modèles ===" && \
+    ls -R server/models/
+
+# Exposer le port
+EXPOSE 5000
+
+# Démarrer l'application
+CMD ["npm", "start"] 

--- a/server/railway.toml
+++ b/server/railway.toml
@@ -1,6 +1,6 @@
 [build]
-builder = "nixpacks"
-buildCommand = "npm ci --production=false && npm run build"
+builder = "DOCKERFILE"
+dockerfilePath = "server/Dockerfile"
 
 [deploy]
 startCommand = "npm start"


### PR DESCRIPTION
- Ajout du Dockerfile pour le serveur
- Configuration Railway pour utiliser Docker
- Suppression de la configuration Render

Le Dockerfile :
- Utilise node:18-alpine
- Installe les dépendances avec production=false
- Vérifie les modèles
- Configure le port 5000