### PR TITLE
fix: suppression de la directive de cache pour Railway

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,8 +7,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Installer les dépendances avec un cache correct
-RUN --mount=type=cache,id=npm,target=/root/.npm \
-    npm ci
+RUN npm ci
 
 # Copier le reste des fichiers
 COPY . .


### PR DESCRIPTION
- Suppression de la directive --mount=type=cache qui n'est pas supportée par Railway
- Simplification de l'installation des dépendances avec npm ci
- Conservation de la structure multi-stage pour l'optimisation