### PR TITLE
fix: simplification de l'installation npm

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,11 +5,8 @@ WORKDIR /app
 # Copier les fichiers de dépendances
 COPY package*.json ./
 
-# Installation des dépendances en mode production
-RUN npm set progress=false && \
-    npm config set cache /tmp/empty-cache && \
-    npm install --production && \
-    rm -rf /tmp/empty-cache
+# Installation simple des dépendances
+RUN npm install --omit=dev
 
 # Copier le reste des fichiers
 COPY . .


### PR DESCRIPTION
- Utilisation de npm install --omit=dev
- Suppression de la gestion du cache
- Configuration minimale pour le déploiement